### PR TITLE
Add support for `picture` nodes with multiple `source` children

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -7,6 +7,23 @@ document.addEventListener('mousedown', e => {
 	}
 });
 
+function parsePictureNode(element) {
+	const urls = new Set();
+
+	element.childNodes.forEach(childNode => {
+		if (!childNode.srcset) return;
+
+		childNode.srcset.split(',').forEach(src => {
+			const [url] = src.trim().split(' ');
+			if (url) {
+				urls.add(url);
+			}
+		});
+	});
+
+	return Array.from(urls.values());
+}
+
 chrome.runtime.onMessage.addListener((data, sender, sendResponse) => {
 	sendResponse({status: 'ok'});
 
@@ -18,6 +35,9 @@ chrome.runtime.onMessage.addListener((data, sender, sendResponse) => {
 	}).forEach(e => {
 		if (typeof e.src !== "undefined") {
 			images.push(e.src);
+		}
+		if (e.tagName.toLowerCase() === 'picture') {
+			images.push(...parsePictureNode(e));
 		}
 		const style = window.getComputedStyle(e, false);
 		if (typeof style !== "undefined") {


### PR DESCRIPTION
I absolutely love this extension - super helpful. I noticed that it didn't support `picture` elements when attempting to use it to download some album art from music.apple.com.

This PR adds `picture` support by checking child nodes for a `srcset` attribute. We don't have direct access to the `source` elements within `picture` since they render as 0px/0px.